### PR TITLE
Added option to have custom GStats container

### DIFF
--- a/src/com/genome2d/context/stats/GStats.hx
+++ b/src/com/genome2d/context/stats/GStats.hx
@@ -35,19 +35,23 @@ class GStats implements IGStats
     private var g2d_previousTime:Float = 0;
     private var g2d_fpsText:DivElement;
 
-    private var g2d_container:DivElement;
+    private var g2d_container:Element;
     private var g2d_fpsDiv:DivElement;
 
     public function new(p_canvas:Element) {
         g2d_previousTime = Date.now().getTime();
         fps = 0;
 
-        g2d_container = Browser.document.createDivElement();
-        g2d_container.id = 'stats';
-        g2d_container.style.cssText = 'width:'+p_canvas.clientWidth+'px;opacity:0.9;cursor:pointer';
-        g2d_container.style.position = "absolute";
-        g2d_container.style.left = p_canvas.offsetLeft+'px';
-        g2d_container.style.top = p_canvas.offsetTop+'px';
+        g2d_container = Browser.document.getElementById('stats');
+        if (g2d_container == null) {
+
+            g2d_container = Browser.document.createDivElement();
+            g2d_container.id = 'stats';
+            g2d_container.style.cssText = 'width:'+p_canvas.clientWidth+'px;opacity:0.9;cursor:pointer';
+            g2d_container.style.position = "absolute";
+            g2d_container.style.left = p_canvas.offsetLeft+'px';
+            g2d_container.style.top = p_canvas.offsetTop+'px';
+        }
 
         g2d_fpsDiv = Browser.document.createDivElement();
         g2d_fpsDiv.id = 'fps';


### PR DESCRIPTION
**GStats** container can be now defined as custom element in HTML.

For example:

`<div id="stats" style="position:absolute; top:0; left:0;"></div>`