### PR TITLE
[WebGL] Force texture rebind after frame buffer change

### DIFF
--- a/src/com/genome2d/context/GWebGLContext.hx
+++ b/src/com/genome2d/context/GWebGLContext.hx
@@ -401,6 +401,9 @@ implements IGFocusable
             g2d_projectionMatrix.orthoRtt(p_texture.nativeWidth, p_texture.nativeHeight, null);
             g2d_projectionMatrix.transpose();
             g2d_nativeContext.disable(RenderingContext.SCISSOR_TEST);
+
+            // Indicate that active texture needs rebind after frame buffer change
+            g2d_drawRenderer.activeTextureNeedsRebind();
         }
 
         g2d_renderTargetMatrix = p_transform;

--- a/src/com/genome2d/context/renderers/GQuadTextureShaderRenderer.hx
+++ b/src/com/genome2d/context/renderers/GQuadTextureShaderRenderer.hx
@@ -140,6 +140,7 @@ class GQuadTextureShaderRenderer implements IGRenderer
 
     private var g2d_initialized:Int = -1;
     private var g2d_activeFilter:GFilter;
+    private var g2d_activeTextureNeedsRebind:Bool = false;
 
 	private var g2d_defaultProgram:Dynamic;
     private var g2d_currentProgram:Dynamic;
@@ -346,7 +347,7 @@ class GQuadTextureShaderRenderer implements IGRenderer
         // TODO: Change this if we implement separate alpha pipeline
         g2d_activeAlpha = useAlpha;
 
-        if (notSameTexture || notSameFilter) {
+        if (notSameTexture || notSameFilter || g2d_activeTextureNeedsRebind) {
             if (g2d_activeNativeTexture != null) push();
 
             if (notSameFilter) {
@@ -369,7 +370,9 @@ class GQuadTextureShaderRenderer implements IGRenderer
                 }
             }
 
-            if (notSameTexture) {
+            if (notSameTexture || g2d_activeTextureNeedsRebind) {
+                g2d_activeTextureNeedsRebind = false;
+
                 g2d_activeNativeTexture = p_texture.nativeTexture;
                 g2d_nativeContext.activeTexture(RenderingContext.TEXTURE0);
                 g2d_nativeContext.bindTexture(RenderingContext.TEXTURE_2D, p_texture.nativeTexture);
@@ -438,8 +441,15 @@ class GQuadTextureShaderRenderer implements IGRenderer
         }
     }
 
+    public function activeTextureNeedsRebind():Void {
+        if (g2d_activeNativeTexture != null) {
+            g2d_activeTextureNeedsRebind = true;
+        }
+    }
+
     public function clear():Void {
         g2d_activeNativeTexture = null;
+        g2d_activeTextureNeedsRebind = false;
 
         if (g2d_activeFilter != null) {
             g2d_activeFilter.clear(g2d_context);


### PR DESCRIPTION
Rendering the same texture to different render textures in a row causes black rectangles to be rendered instead of an actual texture. 

![image](https://user-images.githubusercontent.com/26201241/78770698-397d0400-798f-11ea-8ef3-5ed48b4dddec.png)

Fixed by forcing **bindTexture** call before next texture render to different render target